### PR TITLE
Removed unnecessary cleanup of resources.

### DIFF
--- a/phlow/deliver.go
+++ b/phlow/deliver.go
@@ -45,7 +45,6 @@ func Deliver(defaultBranch string) {
 		return
 	}
 
-	ui.PhlowSpinner.Stop()
 	fmt.Printf("Delivered branch %s \n", ui.Format.Branch(branchInfo.Current))
 }
 
@@ -90,7 +89,7 @@ func LocalDeliver(defaultBranch string) {
 		fmt.Println(err.Error())
 		return
 	}
-	ui.PhlowSpinner.Stop()
+
 	fmt.Printf("Delivered changes from %s to %s \n", ui.Format.Branch(branchInfo.Current), ui.Format.Branch(defaultBranch))
 }
 

--- a/phlow/workon.go
+++ b/phlow/workon.go
@@ -14,6 +14,7 @@ import (
 //WorkOn ...
 func WorkOn(issue int) {
 	ui.PhlowSpinner.Start("Setting up workspace")
+
 	defer ui.PhlowSpinner.Stop()
 	if err := githandler.Fetch(); err != nil {
 		fmt.Println(err)
@@ -70,7 +71,7 @@ func WorkOn(issue int) {
 			return
 		}
 	}
-	ui.PhlowSpinner.Stop()
+
 	fmt.Println("No matching issues")
 }
 


### PR DESCRIPTION
It should be unnecessary to close the PhlowSpinner before the function returns, as this is what defer should  do for you. 